### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/graysonarts/git-superprune/compare/v0.1.2...v0.1.3) - 2024-07-18
+
+### Other
+- Add .envrc to gitignore ([#5](https://github.com/graysonarts/git-superprune/pull/5))
+- Audit Dependencies and Add Deny config ([#4](https://github.com/graysonarts/git-superprune/pull/4))
+- CircleCI setup ([#3](https://github.com/graysonarts/git-superprune/pull/3))
+
 ## [0.1.2](https://github.com/graysonarts/git-superprune/compare/v0.1.1...v0.1.2) - 2024-06-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git-superprune"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-superprune"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "A tool to prune merged remote branches from the local repository."


### PR DESCRIPTION
## 🤖 New release
* `git-superprune`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/graysonarts/git-superprune/compare/v0.1.2...v0.1.3) - 2024-07-18

### Other
- Add .envrc to gitignore ([#5](https://github.com/graysonarts/git-superprune/pull/5))
- Audit Dependencies and Add Deny config ([#4](https://github.com/graysonarts/git-superprune/pull/4))
- CircleCI setup ([#3](https://github.com/graysonarts/git-superprune/pull/3))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).